### PR TITLE
Add docker-compose setup and demo HTML

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+services:
+  tts:
+    build: .
+    ports:
+      - "5002:5002"
+    command: ["--model_name", "tts_models/multilingual/multi-dataset/your_tts", "--use_cuda", "false"]
+  web:
+    image: nginx:alpine
+    ports:
+      - "8080:80"
+    volumes:
+      - ./index.html:/usr/share/nginx/html/index.html:ro

--- a/index.html
+++ b/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Coqui TTS Voice Cloning Demo</title>
+</head>
+<body>
+  <h1>Coqui TTS Voice Cloning Demo</h1>
+  <input type="file" id="fileInput" accept="audio/wav"><br>
+  <textarea id="textInput" rows="4" cols="50" placeholder="Enter text here"></textarea><br>
+  <button id="speakBtn">Speak</button><br>
+  <audio id="audio" controls></audio>
+  <script>
+    document.getElementById('speakBtn').addEventListener('click', async () => {
+      const fileInput = document.getElementById('fileInput');
+      const text = document.getElementById('textInput').value;
+      const formData = new FormData();
+      formData.append('text', text);
+      if (fileInput.files[0]) {
+        formData.append('speaker_wav', fileInput.files[0]);
+      }
+      const response = await fetch('http://localhost:5002/api/tts', {
+        method: 'POST',
+        body: formData,
+      });
+      const arrayBuffer = await response.arrayBuffer();
+      const blob = new Blob([arrayBuffer], { type: 'audio/wav' });
+      const audioURL = URL.createObjectURL(blob);
+      const audio = document.getElementById('audio');
+      audio.src = audioURL;
+      audio.play();
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- provide a docker-compose file to start the TTS server and a small web server
- add `index.html` demo page to upload a wav file, enter text and play back the generated speech

## Testing
- `docker-compose --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840153ec2fc832eb4333c5410e34d99